### PR TITLE
Fixes #48 - Exception raised when parsing rs1compatibilitydlc_p.psarc

### DIFF
--- a/RocksmithToTabLib/PSARCBrowser.cs
+++ b/RocksmithToTabLib/PSARCBrowser.cs
@@ -139,7 +139,7 @@ namespace RocksmithToTabLib
             using (var reader = new StreamReader(jsonFile.Data.OpenStream()))
             {
                 var manifest = JsonConvert.DeserializeObject<Manifest2014<Attributes2014>>(
-                    reader.ReadToEnd());
+                    reader.ReadToEnd(), new JsonSerializerSettings { NullValueHandling = NullValueHandling.Ignore });
                 if (manifest == null)
                     return null;
                 attr = manifest.Entries.ToArray()[0].Value.ToArray()[0].Value;


### PR DESCRIPTION
Opening archive rs1compatibilitydlc_p.psarc and parsing (108/143) song pumpedupkicks throws an unhandled exception:

Unhandled Exception: Newtonsoft.Json.JsonSerializationException: Error converting value {null} to type 'System.Int32'. Path 'Entries.C7A72C01B0BF25D683906F6BF171040A.Attributes.LeaderboardChallengeRating', line 592, position 41. ---> System.InvalidCastException: Null object cannot be converted to a value type.
   at System.Convert.ChangeType(Object value, Type conversionType, IFormatProvider provider)
   at Newtonsoft.Json.Serialization.JsonSerializerInternalReader.EnsureType(JsonReader reader, Object value, CultureInfo culture, JsonContract contract, Type targetType)
   --- End of inner exception stack trace ---

Added an option to ignore null values when invoking JSON library:

new JsonSerializerSettings { NullValueHandling = NullValueHandling.Ignore }

Thank you for the awesome tool! :-)